### PR TITLE
Pass cluster host

### DIFF
--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -290,7 +290,7 @@ void RedisCluster::RedisDiscoverySession::startResolveRedis() {
   if (!client) {
     client = std::make_unique<RedisDiscoveryClient>(*this);
     client->host_ = current_host_address_;
-    client->client_ = client_factory_.create(host, dispatcher_, *this, redis_command_stats_,
+    client->client_ = client_factory_.create(nullptr, host, dispatcher_, *this, redis_command_stats_,
                                              parent_.info()->statsScope(), parent_.auth_username_,
                                              parent_.auth_password_);
     client->client_->addConnectionCallbacks(*client);

--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -290,9 +290,9 @@ void RedisCluster::RedisDiscoverySession::startResolveRedis() {
   if (!client) {
     client = std::make_unique<RedisDiscoveryClient>(*this);
     client->host_ = current_host_address_;
-    client->client_ = client_factory_.create(nullptr, host, dispatcher_, *this, redis_command_stats_,
+    client->client_ = client_factory_.create(host, dispatcher_, *this, redis_command_stats_,
                                              parent_.info()->statsScope(), parent_.auth_username_,
-                                             parent_.auth_password_);
+                                             parent_.auth_password_, nullptr);
     client->client_->addConnectionCallbacks(*client);
   }
 

--- a/source/extensions/filters/network/common/redis/cache_impl.cc
+++ b/source/extensions/filters/network/common/redis/cache_impl.cc
@@ -88,6 +88,10 @@ void CacheImpl::onFailure() {
     }
 }
 
+CacheImpl::~CacheImpl() {
+    this->client_->close();
+}
+
 CacheImpl::PendingCacheRequest::PendingCacheRequest(const Operation op) : op_(op) {}
 
 } // namespace Redis

--- a/source/extensions/filters/network/common/redis/cache_impl.h
+++ b/source/extensions/filters/network/common/redis/cache_impl.h
@@ -21,8 +21,8 @@ enum class Operation {
 class CacheImpl : public Client::Cache, public Logger::Loggable<Logger::Id::redis>, public Client::ClientCallbacks {
 public:
   CacheImpl(Client::ClientPtr&& client) : client_(std::move(client)) {}
+  ~CacheImpl() override;
   void makeCacheRequest(const RespValue& request) override;
-  //void set(const std::string &key, RespValuePtr&& value) override;
   void set(const std::string &key, const std::string& value) override;
   void expire(const std::string &key) override;
   void addCallbacks(Client::CacheCallbacks& callbacks) override {

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -205,7 +205,8 @@ public:
    * @param auth password for upstream host.
    * @return ClientPtr a new connection pool client.
    */
-  virtual ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
+  virtual ClientPtr create(Upstream::HostConstSharedPtr cache_host,
+                           Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                            const Config& config,
                            const RedisCommandStatsSharedPtr& redis_command_stats,
                            Stats::Scope& scope, const std::string& auth_username,

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -220,12 +220,11 @@ public:
 };
 
 
-class Cache {
+class Cache : public Event::DeferredDeletable {
 public:
-  virtual ~Cache() = default;
+  ~Cache() override = default;
 
   virtual void makeCacheRequest(const RespValue& request) PURE;
-  //virtual void set(const std::string &key, RespValuePtr&& value) PURE;
   virtual void set(const std::string &key, const std::string& value) PURE;
   virtual void expire(const std::string &key) PURE;
   virtual void addCallbacks(CacheCallbacks& callbacks) PURE;

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -205,12 +205,12 @@ public:
    * @param auth password for upstream host.
    * @return ClientPtr a new connection pool client.
    */
-  virtual ClientPtr create(Upstream::HostConstSharedPtr cache_host,
-                           Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
+  virtual ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                            const Config& config,
                            const RedisCommandStatsSharedPtr& redis_command_stats,
                            Stats::Scope& scope, const std::string& auth_username,
-                           const std::string& auth_password) PURE;
+                           const std::string& auth_password,
+                           Upstream::HostConstSharedPtr cache_host) PURE;
 };
 
 class CacheCallbacks {

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -434,12 +434,12 @@ void ClientImpl::initialize(const std::string& auth_username, const std::string&
 
 ClientFactoryImpl ClientFactoryImpl::instance_;
 
-ClientPtr ClientFactoryImpl::create(Upstream::HostConstSharedPtr cache_host,
-                                    Upstream::HostConstSharedPtr host,
+ClientPtr ClientFactoryImpl::create(Upstream::HostConstSharedPtr host,
                                     Event::Dispatcher& dispatcher, const Config& config,
                                     const RedisCommandStatsSharedPtr& redis_command_stats,
                                     Stats::Scope& scope, const std::string& auth_username,
-                                    const std::string& auth_password) {
+                                    const std::string& auth_password,
+                                    Upstream::HostConstSharedPtr cache_host) {
   CachePtr cp = nullptr;
   if (cache_host != nullptr) {
     ClientPtr cache_client = ClientImpl::create(cache_host, dispatcher, EncoderPtr{new EncoderImpl()},

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -169,10 +169,10 @@ private:
 class ClientFactoryImpl : public ClientFactory {
 public:
   // RedisProxy::ConnPool::ClientFactoryImpl
-  ClientPtr create(Upstream::HostConstSharedPtr cache_host, Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
+  ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                    const Config& config, const RedisCommandStatsSharedPtr& redis_command_stats,
                    Stats::Scope& scope, const std::string& auth_username,
-                   const std::string& auth_password) override;
+                   const std::string& auth_password, Upstream::HostConstSharedPtr cache_host) override;
 
   static ClientFactoryImpl instance_;
 

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -169,7 +169,7 @@ private:
 class ClientFactoryImpl : public ClientFactory {
 public:
   // RedisProxy::ConnPool::ClientFactoryImpl
-  ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
+  ClientPtr create(Upstream::HostConstSharedPtr cache_host, Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                    const Config& config, const RedisCommandStatsSharedPtr& redis_command_stats,
                    Stats::Scope& scope, const std::string& auth_username,
                    const std::string& auth_password) override;

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -252,8 +252,8 @@ InstanceImpl::ThreadLocalPool::threadLocalActiveClient(Upstream::HostConstShared
     }
 
     client->redis_client_ =
-        client_factory_.create(cache_host, host, dispatcher_, *config_, redis_command_stats_, *(stats_scope_),
-                               auth_username_, auth_password_);
+        client_factory_.create(host, dispatcher_, *config_, redis_command_stats_, *(stats_scope_),
+                               auth_username_, auth_password_, cache_host);
     client->redis_client_->addConnectionCallbacks(*client);
   }
   return client;

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "envoy/common/exception.h"
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/core/v3/health_check.pb.h"
 #include "envoy/config/endpoint/v3/endpoint_components.pb.h"
@@ -235,8 +236,23 @@ InstanceImpl::ThreadLocalPool::threadLocalActiveClient(Upstream::HostConstShared
   if (!client) {
     client = std::make_unique<ThreadLocalActiveClient>(*this);
     client->host_ = host;
+
+    // Ensure the filter is not deleted in the main thread during this method.
+    auto shared_parent = parent_.lock();
+    if (!shared_parent) {
+      throw EnvoyException("Filter was deleted in the main thread");
+    }
+
+    // TODO(slava): make this configurable
+    Upstream::HostConstSharedPtr cache_host = nullptr;
+    auto cache_cluster = shared_parent->cm_.getThreadLocalCluster("redis_cache_cluster");
+    if (cache_cluster != nullptr) {
+      cache_host = cache_cluster->loadBalancer().chooseHost(nullptr);
+      ASSERT(cache_host != nullptr);
+    }
+
     client->redis_client_ =
-        client_factory_.create(host, dispatcher_, *config_, redis_command_stats_, *(stats_scope_),
+        client_factory_.create(cache_host, host, dispatcher_, *config_, redis_command_stats_, *(stats_scope_),
                                auth_username_, auth_password_);
     client->redis_client_->addConnectionCallbacks(*client);
   }

--- a/source/extensions/health_checkers/redis/redis.cc
+++ b/source/extensions/health_checkers/redis/redis.cc
@@ -66,7 +66,7 @@ void RedisHealthChecker::RedisActiveHealthCheckSession::onEvent(Network::Connect
 
 void RedisHealthChecker::RedisActiveHealthCheckSession::onInterval() {
   if (!client_) {
-    client_ = parent_.client_factory_.create(
+    client_ = parent_.client_factory_.create(nullptr,
         host_, parent_.dispatcher_, *this, redis_command_stats_,
         parent_.cluster_.info()->statsScope(), parent_.auth_username_, parent_.auth_password_);
     client_->addConnectionCallbacks(*this);

--- a/source/extensions/health_checkers/redis/redis.cc
+++ b/source/extensions/health_checkers/redis/redis.cc
@@ -66,9 +66,10 @@ void RedisHealthChecker::RedisActiveHealthCheckSession::onEvent(Network::Connect
 
 void RedisHealthChecker::RedisActiveHealthCheckSession::onInterval() {
   if (!client_) {
-    client_ = parent_.client_factory_.create(nullptr,
+    client_ = parent_.client_factory_.create(
         host_, parent_.dispatcher_, *this, redis_command_stats_,
-        parent_.cluster_.info()->statsScope(), parent_.auth_username_, parent_.auth_password_);
+        parent_.cluster_.info()->statsScope(), parent_.auth_username_, parent_.auth_password_,
+        nullptr);
     client_->addConnectionCallbacks(*this);
   }
 


### PR DESCRIPTION
This enables the use of a envoy cluster that is defined by configuration rather than piggybacking on the original cluster for the cache host. This PR also fixes up the statistics so they are properly attributed to the correct stats scope and removes the double counting of requests to the cluster when request was actually served by cache.