### PR TITLE
propagate cache connection close

### DIFF
--- a/source/extensions/filters/network/common/redis/cache_impl.cc
+++ b/source/extensions/filters/network/common/redis/cache_impl.cc
@@ -88,6 +88,13 @@ void CacheImpl::onFailure() {
     }
 }
 
+void CacheImpl::onEvent(Network::ConnectionEvent event) {
+    if (event == Network::ConnectionEvent::RemoteClose ||
+        event == Network::ConnectionEvent::LocalClose) {
+        callbacks_.front()->onCacheClose();
+    }
+}
+
 CacheImpl::~CacheImpl() {
     this->client_->close();
 }

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -217,6 +217,7 @@ class CacheCallbacks {
 public:
   virtual ~CacheCallbacks() = default;
   virtual void onCacheResponse(RespValuePtr&& value) PURE;
+  virtual void onCacheClose() PURE;
 };
 
 

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -302,7 +302,7 @@ void ClientImpl::onCacheResponse(RespValuePtr&& value) {
 }
 
 void ClientImpl::onCacheClose() {
-  // Propogate the close
+  // Propagate the close
   if (this->connected_) {
     this->close();
   }

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -301,6 +301,13 @@ void ClientImpl::onCacheResponse(RespValuePtr&& value) {
   }
 }
 
+void ClientImpl::onCacheClose() {
+  // Propogate the close
+  if (this->connected_) {
+    this->close();
+  }
+}
+
 void ClientImpl::onRespValue(RespValuePtr&& value) {
   ENVOY_LOG(info, this->host_->address()->asString());
   if (cache_ && value->type() == Common::Redis::RespType::Push && PushResponse::get().INVALIDATE == value->asArray()[0].asString()) {

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -143,6 +143,7 @@ private:
 
   // CacheCallbacks
   void onCacheResponse(RespValuePtr&& value) override;
+  void onCacheClose() override;
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;


### PR DESCRIPTION
Ensure that when the cache client connection is closed that this is propagated back to the regular client and it too closes its connection.