### PR TITLE
Ensure pending cache requests have callback called

### DIFF
--- a/source/extensions/filters/network/common/redis/cache_impl.cc
+++ b/source/extensions/filters/network/common/redis/cache_impl.cc
@@ -74,18 +74,7 @@ void CacheImpl::onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) 
 
 void CacheImpl::onFailure() {
     ASSERT(!pending_requests_.empty());
-
-    PendingCacheRequest& req = pending_requests_.front();
     pending_requests_.pop_front();
-
-    switch (req.op_) {
-    case Operation::Set:
-    case Operation::Expire:
-    break;
-    case Operation::Get:
-        callbacks_.front()->onCacheResponse(nullptr);
-    break;
-    }
 }
 
 void CacheImpl::onEvent(Network::ConnectionEvent event) {

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -207,6 +207,14 @@ void ClientImpl::onEvent(Network::ConnectionEvent event) {
       }
     }
 
+    while (!pending_cache_requests_.empty()) {
+      PendingRequestPtr& request = pending_cache_requests_.front();
+      if (!request->canceled_) {
+        request->callbacks_.onFailure();
+      }
+      pending_cache_requests_.pop_front();
+    }
+
     while (!pending_requests_.empty()) {
       PendingRequestPtr& request = pending_requests_.front();
       if (!request->canceled_) {


### PR DESCRIPTION
On a close event the `onFailure` callback should be triggered for cache requests. Then on cache request `onFailure` should not propagate the error up. The request is already canceled.