### PR TITLE
Clear cache on first connect

### DIFF
--- a/source/extensions/filters/network/common/redis/cache_impl.h
+++ b/source/extensions/filters/network/common/redis/cache_impl.h
@@ -15,7 +15,8 @@ namespace Redis {
 enum class Operation {
   Get,
   Set,
-  Expire
+  Expire,
+  Flush
 };
 
 class CacheImpl : public Client::Cache, public Logger::Loggable<Logger::Id::redis>, public Client::ClientCallbacks, public Network::ConnectionCallbacks {
@@ -30,6 +31,8 @@ public:
   void addCallbacks(Client::CacheCallbacks& callbacks) override {
     this->callbacks_.push_front(&callbacks);
   }
+  void clearCache(bool synchronous) override;
+  void initialize(const std::string& auth_username, const std::string& auth_password, bool clear_cache) override;
 
   // Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks
   void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -229,6 +229,8 @@ public:
   virtual void set(const std::string &key, const std::string& value) PURE;
   virtual void expire(const std::string &key) PURE;
   virtual void addCallbacks(CacheCallbacks& callbacks) PURE;
+  virtual void clearCache(bool synchronous) PURE;
+  virtual void initialize(const std::string& auth_username, const std::string& auth_password, bool clear_cache) PURE;
 };
 
 using CachePtr = std::unique_ptr<Cache>;
@@ -236,7 +238,7 @@ using CachePtr = std::unique_ptr<Cache>;
 class CacheFactory {
 public:
   virtual ~CacheFactory() = default;
-  virtual CachePtr create(ClientPtr&& client) PURE; //  ClientFactory& client_factory
+  virtual CachePtr create(ClientPtr&& client) PURE;
 };
 
 } // namespace Client


### PR DESCRIPTION
We need to make sure the cache is never stale in the event Envoy ever drops the connection (timeout, dies, etc). To ensure this, on connect we always flush the cache. I may revisit this later on if we opt to operate this with `concurrency != 1`.