### PR TITLE
expire array of keys and use unlink instead of delete

### DIFF
--- a/source/extensions/filters/network/common/redis/cache_impl.h
+++ b/source/extensions/filters/network/common/redis/cache_impl.h
@@ -27,7 +27,7 @@ public:
   ~CacheImpl() override;
   void makeCacheRequest(const RespValue& request) override;
   void set(const std::string &key, const std::string& value) override;
-  void expire(const std::string &key) override;
+  void expire(const RespValue& keys) override;
   void addCallbacks(Client::CacheCallbacks& callbacks) override {
     this->callbacks_.push_front(&callbacks);
   }

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -227,7 +227,7 @@ public:
 
   virtual void makeCacheRequest(const RespValue& request) PURE;
   virtual void set(const std::string &key, const std::string& value) PURE;
-  virtual void expire(const std::string &key) PURE;
+  virtual void expire(const RespValue& keys) PURE;
   virtual void addCallbacks(CacheCallbacks& callbacks) PURE;
   virtual void clearCache(bool synchronous) PURE;
   virtual void initialize(const std::string& auth_username, const std::string& auth_password, bool clear_cache) PURE;

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -315,15 +315,7 @@ void ClientImpl::onCacheClose() {
 void ClientImpl::onRespValue(RespValuePtr&& value) {
   if (cache_ && value->type() == Common::Redis::RespType::Push && PushResponse::get().INVALIDATE == value->asArray()[0].asString()) {
     ASSERT(value->asArray().size() == 2);
-
-    if (value->asArray()[1].type() == Common::Redis::RespType::BulkString) {
-      cache_->expire(value->asArray()[1].asArray()[0].asString());
-    } else if (value->asArray()[1].type() == Common::Redis::RespType::Null) {
-      // On Null it means the FLUSHALL was run on Redis and entire cache must
-      // be cleared.
-      cache_->clearCache(true);
-    }
-
+    cache_->expire(value->asArray()[1]);
     return;
   }
 


### PR DESCRIPTION
Handle case where server responds with a list of keys that need to be invalidated.