### PR TITLE
handle caching mget requests / respones

### DIFF
--- a/source/extensions/filters/network/common/redis/cache_impl.h
+++ b/source/extensions/filters/network/common/redis/cache_impl.h
@@ -26,7 +26,7 @@ public:
   }
   ~CacheImpl() override;
   void makeCacheRequest(const RespValue& request) override;
-  void set(const std::string &key, const std::string& value) override;
+  void set(const RespValue& request, const RespValue& response) override;
   void expire(const RespValue& keys) override;
   void addCallbacks(Client::CacheCallbacks& callbacks) override {
     this->callbacks_.push_front(&callbacks);

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -226,7 +226,7 @@ public:
   ~Cache() override = default;
 
   virtual void makeCacheRequest(const RespValue& request) PURE;
-  virtual void set(const std::string &key, const std::string& value) PURE;
+  virtual void set(const RespValue& request, const RespValue& response) PURE;
   virtual void expire(const RespValue& keys) PURE;
   virtual void addCallbacks(CacheCallbacks& callbacks) PURE;
   virtual void clearCache(bool synchronous) PURE;

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -133,8 +133,9 @@ PoolRequest* ClientImpl::makeRequest(const RespValue& request, ClientCallbacks& 
 
   PendingRequestPtr prp{new PendingRequest(*this, callbacks, command, request)};
 
-  if (cache_ && request.type() == RespType::Array &&
-        absl::AsciiStrToLower(request.asArray()[0].asString()) == "get") {
+  if (cache_ && (
+        (request.type() == RespType::Array && absl::AsciiStrToLower(request.asArray()[0].asString()) == "get") ||
+        (request.type() == RespType::CompositeArray && absl::AsciiStrToLower(request.asCompositeArray().command()->asString()) == "get"))) {
     pending_cache_requests_.push_back(std::move(prp));
     cache_->makeCacheRequest(request);
     return pending_cache_requests_.back().get();
@@ -364,11 +365,8 @@ void ClientImpl::onRespValue(RespValuePtr&& value) {
     }
   } else {
     // If request is a get then fire and forget cache set request
-    if (cache_ &&
-      request->request_.type() == RespType::Array &&
-      absl::AsciiStrToLower(request->request_.asArray()[0].asString()) == "get" &&
-      (value->type() == RespType::SimpleString || value->type() == RespType::BulkString)) {
-      cache_->set(request->request_.asArray()[1].asString(), value->asString());
+    if (cache_) {
+      cache_->set(request->request_, *value);
     }
 
     callbacks.onResponse(std::move(value));


### PR DESCRIPTION
Internally `MGET` requests are converted into `GET`s but these requests are treated as `CompositeArray`s. This PR adds handling for `MGET` requests and associated responses.