### PR TITLE
expose caching config via envoy config file

### DIFF
--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -28,7 +28,7 @@ message RedisProxy {
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
 
   // Redis connection pool settings.
-  // [#next-free-field: 9]
+  // [#next-free-field: 14]
   message ConnPoolSettings {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings";
@@ -118,6 +118,42 @@ message RedisProxy {
 
     // Read policy. The default is to read from the primary.
     ReadPolicy read_policy = 7 [(validate.rules).enum = {defined_only: true}];
+
+    // Specifies the cluster that cache requests will go to. The cluster must
+    // exist in the cluster manager configuration.
+    string cache_cluster = 9;
+
+    // Per-operation timeout in milliseconds for cache requests. The timer starts when the first
+    // command of a pipeline is written to the backend connection. Each response received from Redis
+    // resets the timer since it signifies that the next command is being processed by the backend.
+    // The only exception to this behavior is when a connection to a backend is not yet established.
+    // In that case, the connect timeout on the cluster will govern the timeout until the connection
+    // is ready. Default is 20ms.
+    google.protobuf.Duration cache_op_timeout = 10;
+
+    // Maximum size of encoded request buffer before flush is triggered and encoded cache requests
+    // are sent upstream. If this is unset, the buffer flushes whenever it receives data
+    // and performs no batching.
+    // This feature makes it possible for multiple clients to send requests to Envoy and have
+    // them batched- for example if one is running several worker processes, each with its own
+    // Redis connection. There is no benefit to using this with a single downstream process.
+    // Recommended size (if enabled) is 1024 bytes.
+    google.protobuf.UInt32Value cache_max_buffer_size_before_flush = 11;
+
+    // The encoded cache request buffer is flushed N milliseconds after the first request has been
+    // encoded, unless the buffer size has already exceeded `max_buffer_size_before_flush`.
+    // If `max_buffer_size_before_flush` is not set, this flush timer is not used. Otherwise,
+    // the timer should be set according to the number of clients, overall request rate and
+    // desired maximum latency for a single command. For example, if there are many requests
+    // being batched together at a high rate, the buffer will likely be filled before the timer
+    // fires. Alternatively, if the request rate is lower the buffer will not be filled as often
+    // before the timer fires.
+    // If `max_buffer_size_before_flush` is set, but `buffer_flush_timeout` is not, the latter
+    // defaults to 3ms.
+    google.protobuf.Duration cache_buffer_flush_timeout = 12;
+
+    // Per key TTL for cached keys in milliseconds.
+    google.protobuf.Duration cache_ttl = 13;
   }
 
   message PrefixRoutes {

--- a/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -29,7 +29,7 @@ message RedisProxy {
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
 
   // Redis connection pool settings.
-  // [#next-free-field: 9]
+  // [#next-free-field: 14]
   message ConnPoolSettings {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings";
@@ -119,6 +119,42 @@ message RedisProxy {
 
     // Read policy. The default is to read from the primary.
     ReadPolicy read_policy = 7 [(validate.rules).enum = {defined_only: true}];
+
+    // Specifies the cluster that cache requests will go to. The cluster must
+    // exist in the cluster manager configuration.
+    string cache_cluster = 9;
+
+    // Per-operation timeout in milliseconds for cache requests. The timer starts when the first
+    // command of a pipeline is written to the backend connection. Each response received from Redis
+    // resets the timer since it signifies that the next command is being processed by the backend.
+    // The only exception to this behavior is when a connection to a backend is not yet established.
+    // In that case, the connect timeout on the cluster will govern the timeout until the connection
+    // is ready. Default is 20ms.
+    google.protobuf.Duration cache_op_timeout = 10;
+
+    // Maximum size of encoded request buffer before flush is triggered and encoded cache requests
+    // are sent upstream. If this is unset, the buffer flushes whenever it receives data
+    // and performs no batching.
+    // This feature makes it possible for multiple clients to send requests to Envoy and have
+    // them batched- for example if one is running several worker processes, each with its own
+    // Redis connection. There is no benefit to using this with a single downstream process.
+    // Recommended size (if enabled) is 1024 bytes.
+    google.protobuf.UInt32Value cache_max_buffer_size_before_flush = 11;
+
+    // The encoded cache request buffer is flushed N milliseconds after the first request has been
+    // encoded, unless the buffer size has already exceeded `max_buffer_size_before_flush`.
+    // If `max_buffer_size_before_flush` is not set, this flush timer is not used. Otherwise,
+    // the timer should be set according to the number of clients, overall request rate and
+    // desired maximum latency for a single command. For example, if there are many requests
+    // being batched together at a high rate, the buffer will likely be filled before the timer
+    // fires. Alternatively, if the request rate is lower the buffer will not be filled as often
+    // before the timer fires.
+    // If `max_buffer_size_before_flush` is set, but `buffer_flush_timeout` is not, the latter
+    // defaults to 3ms.
+    google.protobuf.Duration cache_buffer_flush_timeout = 12;
+
+    // Per key TTL for cached keys in milliseconds.
+    google.protobuf.Duration cache_ttl = 13;
   }
 
   message PrefixRoutes {

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -234,6 +234,23 @@ private:
     Extensions::NetworkFilters::Common::Redis::Client::ReadPolicy readPolicy() const override {
       return Extensions::NetworkFilters::Common::Redis::Client::ReadPolicy::Primary;
     }
+    // Caching
+    std::string cacheCluster() const override {
+      return "";
+    }
+    std::chrono::milliseconds cacheOpTimeout() const override {
+      return std::chrono::milliseconds(20);
+    }
+    unsigned int cacheMaxBufferSizeBeforeFlush() const override {
+      return 0;
+    }
+    // Forces an immediate flush
+    std::chrono::milliseconds cacheBufferFlushTimeoutInMs() const override {
+      return std::chrono::milliseconds(0);
+    }
+    std::chrono::milliseconds cacheTtl() const override {
+      return std::chrono::milliseconds(0);
+    }
 
     // Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks
     void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;

--- a/source/extensions/filters/network/common/redis/cache_impl.cc
+++ b/source/extensions/filters/network/common/redis/cache_impl.cc
@@ -50,9 +50,9 @@ void CacheImpl::set(const RespValue& request, const RespValue& response) {
     // Set a default TTL to ensure that even if we miss an invalidation
     // message from the server that the value will auto expire.
     values[3].type(RespType::BulkString);
-    values[3].asString() = "EX";
+    values[3].asString() = "PX";
     values[4].type(RespType::BulkString);
-    values[4].asString() = "900";
+    values[4].asString() = cache_ttl_;
 
     cache_request->type(RespType::Array);
     cache_request->asArray().swap(values);

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 #include "envoy/upstream/cluster_manager.h"
 
@@ -184,6 +185,32 @@ public:
    * @return the read policy the proxy should use.
    */
   virtual ReadPolicy readPolicy() const PURE;
+
+  /**
+   * @return name of the cluster to use to cache requests.
+   */
+  virtual std::string cacheCluster() const PURE;
+
+  /**
+   * @return std::chrono::milliseconds the timeout for an individual redis operation. Currently,
+   *         all operations use the same timeout.
+   */
+  virtual std::chrono::milliseconds cacheOpTimeout() const PURE;
+
+  /**
+   * @return buffer size for batching commands for a cache upstream host.
+   */
+  virtual uint32_t cacheMaxBufferSizeBeforeFlush() const PURE;
+
+  /**
+   * @return timeout for batching commands for a cache upstream host.
+   */
+  virtual std::chrono::milliseconds cacheBufferFlushTimeoutInMs() const PURE;
+
+  /**
+   * @return per key TTL value for the cache.
+   */
+  virtual std::chrono::milliseconds cacheTtl() const PURE;
 };
 
 using ConfigSharedPtr = std::shared_ptr<Config>;
@@ -238,7 +265,7 @@ using CachePtr = std::unique_ptr<Cache>;
 class CacheFactory {
 public:
   virtual ~CacheFactory() = default;
-  virtual CachePtr create(ClientPtr&& client) PURE;
+  virtual CachePtr create(ClientPtr&& client, std::chrono::milliseconds cache_ttl) PURE;
 };
 
 } // namespace Client

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -66,6 +66,14 @@ public:
   bool enableCommandStats() const override { return enable_command_stats_; }
   ReadPolicy readPolicy() const override { return read_policy_; }
 
+  std::string cacheCluster() const override { return cache_cluster_; }
+  std::chrono::milliseconds cacheOpTimeout() const override { return cache_op_timeout_; }
+  uint32_t cacheMaxBufferSizeBeforeFlush() const override { return cache_max_buffer_size_before_flush_; }
+  std::chrono::milliseconds cacheBufferFlushTimeoutInMs() const override {
+    return cache_buffer_flush_timeout_;
+  }
+  std::chrono::milliseconds cacheTtl() const override { return cache_ttl_; }
+
 private:
   const std::chrono::milliseconds op_timeout_;
   const bool enable_hashtagging_;
@@ -75,6 +83,12 @@ private:
   const uint32_t max_upstream_unknown_connections_;
   const bool enable_command_stats_;
   ReadPolicy read_policy_;
+
+  const std::string cache_cluster_;
+  const std::chrono::milliseconds cache_op_timeout_;
+  const uint32_t cache_max_buffer_size_before_flush_;
+  const std::chrono::milliseconds cache_buffer_flush_timeout_;
+  const std::chrono::milliseconds cache_ttl_;
 };
 
 class ClientImpl : public Client, public DecoderCallbacks, public CacheCallbacks, public Network::ConnectionCallbacks, public Logger::Loggable<Logger::Id::redis> {

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -243,12 +243,14 @@ InstanceImpl::ThreadLocalPool::threadLocalActiveClient(Upstream::HostConstShared
       throw EnvoyException("Filter was deleted in the main thread");
     }
 
-    // TODO(slava): make this configurable
+    // Cache cluster configuration
     Upstream::HostConstSharedPtr cache_host = nullptr;
-    auto cache_cluster = shared_parent->cm_.getThreadLocalCluster("redis_cache_cluster");
-    if (cache_cluster != nullptr) {
-      cache_host = cache_cluster->loadBalancer().chooseHost(nullptr);
-      ASSERT(cache_host != nullptr);
+    if (!config_->cacheCluster().empty()) {
+      auto cache_cluster = shared_parent->cm_.getThreadLocalCluster(config_->cacheCluster());
+      if (cache_cluster != nullptr) {
+        cache_host = cache_cluster->loadBalancer().chooseHost(nullptr);
+        ASSERT(cache_host != nullptr);
+      }
     }
 
     client->redis_client_ =

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -89,6 +89,24 @@ private:
     uint32_t maxUpstreamUnknownConnections() const override { return 0; }
     bool enableCommandStats() const override { return false; }
 
+    // Caching
+    std::string cacheCluster() const override {
+      return "";
+    }
+    std::chrono::milliseconds cacheOpTimeout() const override {
+      return std::chrono::milliseconds(1);
+    }
+    unsigned int cacheMaxBufferSizeBeforeFlush() const override {
+      return 0;
+    }
+    // Forces an immediate flush
+    std::chrono::milliseconds cacheBufferFlushTimeoutInMs() const override {
+      return std::chrono::milliseconds(0);
+    }
+    std::chrono::milliseconds cacheTtl() const override {
+      return std::chrono::milliseconds(0);
+    }
+
     // Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks
     void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;
     void onFailure() override;


### PR DESCRIPTION
Creates the following config settings:

cache_cluster: name of the envoy cluster to use for caching
cache_ttl: amount of time to cache keys for
cache_op_timeout: cache operation timeout
cache_max_buffer_size_before_flush: amount of data to buffer
cache_buffer_flush_timeout: amount of time to spend before force flushing the buffer