### PR TITLE
Add toggle for CSC bcast mode

### DIFF
--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -28,7 +28,7 @@ message RedisProxy {
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
 
   // Redis connection pool settings.
-  // [#next-free-field: 14]
+  // [#next-free-field: 15]
   message ConnPoolSettings {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings";
@@ -154,6 +154,12 @@ message RedisProxy {
 
     // Per key TTL for cached keys in milliseconds.
     google.protobuf.Duration cache_ttl = 13;
+
+    // Enable the use of bcast mode where the client tells Redsd to send all cache invalidation
+    // messages and not just invalidations for keys it requested. This decreases the amount of
+    // overhead the server needs to have per client. However, for Envoy this means that it will
+    // recieve multiple invalidation messages for each worker thread.
+    bool cache_enable_bcast_mode = 14;
   }
 
   message PrefixRoutes {

--- a/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -29,7 +29,7 @@ message RedisProxy {
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
 
   // Redis connection pool settings.
-  // [#next-free-field: 14]
+  // [#next-free-field: 15]
   message ConnPoolSettings {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings";
@@ -155,6 +155,12 @@ message RedisProxy {
 
     // Per key TTL for cached keys in milliseconds.
     google.protobuf.Duration cache_ttl = 13;
+
+    // Enable the use of bcast mode where the client tells Redsd to send all cache invalidation
+    // messages and not just invalidations for keys it requested. This decreases the amount of
+    // overhead the server needs to have per client. However, for Envoy this means that it will
+    // recieve multiple invalidation messages for each worker thread.
+    bool cache_enable_bcast_mode = 14;
   }
 
   message PrefixRoutes {

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -251,6 +251,7 @@ private:
     std::chrono::milliseconds cacheTtl() const override {
       return std::chrono::milliseconds(0);
     }
+    bool cacheEnableBcastMode() const override { return false; };
 
     // Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks
     void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -211,6 +211,13 @@ public:
    * @return per key TTL value for the cache.
    */
   virtual std::chrono::milliseconds cacheTtl() const PURE;
+
+  /**
+   * @return when enabled, client subscribes to all cache invalidations and not just the ones
+   *         keys it requested. This is typically done in order to decrease pressure on the
+   *         upstream Redis servers.
+   */
+  virtual bool cacheEnableBcastMode() const PURE;
 };
 
 using ConfigSharedPtr = std::shared_ptr<Config>;

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -50,7 +50,8 @@ ConfigImpl::ConfigImpl(
       cache_op_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(config, cache_op_timeout, 20)),
       cache_max_buffer_size_before_flush_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, cache_max_buffer_size_before_flush, 0)),
       cache_buffer_flush_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(config, cache_buffer_flush_timeout, 3)),
-      cache_ttl_(PROTOBUF_GET_MS_OR_DEFAULT(config, cache_ttl, 3)) {
+      cache_ttl_(PROTOBUF_GET_MS_OR_DEFAULT(config, cache_ttl, 3)),
+      cache_enable_bcast_mode_(config.cache_enable_bcast_mode()) {
   switch (config.read_policy()) {
   case envoy::extensions::filters::network::redis_proxy::v3::RedisProxy::ConnPoolSettings::MASTER:
     read_policy_ = ReadPolicy::Primary;
@@ -436,7 +437,7 @@ void ClientImpl::initialize(const std::string& auth_username, const std::string&
   // Turn on client tracking
   if (cache_) {
     cache_->addCallbacks(*this);
-    Utility::ClientTrackingRequest client_tracking_request;
+    Utility::ClientTrackingRequest client_tracking_request(config_.cacheEnableBcastMode());
     makeRequest(client_tracking_request, null_pool_callbacks);
   }
 

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -73,6 +73,7 @@ public:
     return cache_buffer_flush_timeout_;
   }
   std::chrono::milliseconds cacheTtl() const override { return cache_ttl_; }
+  bool cacheEnableBcastMode() const override { return cache_enable_bcast_mode_; }
 
 private:
   const std::chrono::milliseconds op_timeout_;
@@ -89,6 +90,7 @@ private:
   const uint32_t cache_max_buffer_size_before_flush_;
   const std::chrono::milliseconds cache_buffer_flush_timeout_;
   const std::chrono::milliseconds cache_ttl_;
+  const bool cache_enable_bcast_mode_;
 };
 
 class ClientImpl : public Client, public DecoderCallbacks, public CacheCallbacks, public Network::ConnectionCallbacks, public Logger::Loggable<Logger::Id::redis> {

--- a/source/extensions/filters/network/common/redis/utility.cc
+++ b/source/extensions/filters/network/common/redis/utility.cc
@@ -41,16 +41,25 @@ HelloRequest::HelloRequest() {
   asArray().swap(values);
 }
 
-ClientTrackingRequest::ClientTrackingRequest() {
-  std::vector<RespValue> values(4);
+ClientTrackingRequest::ClientTrackingRequest(bool enable_bcast_mode) {
+  int val_size = 3;
+  if (enable_bcast_mode) {
+    enable_bcast_mode += 1;
+  }
+
+  std::vector<RespValue> values(val_size);
   values[0].type(RespType::BulkString);
   values[0].asString() = "client";
   values[1].type(RespType::BulkString);
   values[1].asString() = "tracking";
   values[2].type(RespType::BulkString);
   values[2].asString() = "on";
-  values[3].type(RespType::BulkString);
-  values[3].asString() = "bcast";
+
+  if (enable_bcast_mode) {
+    values[3].type(RespType::BulkString);
+    values[3].asString() = "bcast";
+  }
+
   type(RespType::Array);
   asArray().swap(values);
 }

--- a/source/extensions/filters/network/common/redis/utility.h
+++ b/source/extensions/filters/network/common/redis/utility.h
@@ -24,7 +24,7 @@ public:
 
 class ClientTrackingRequest : public Redis::RespValue {
 public:
-  ClientTrackingRequest();
+  ClientTrackingRequest(bool broadcast);
 };
 
 RespValuePtr makeError(const std::string& error);

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -106,6 +106,7 @@ private:
     std::chrono::milliseconds cacheTtl() const override {
       return std::chrono::milliseconds(0);
     }
+    bool cacheEnableBcastMode() const override { return false; };
 
     // Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks
     void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;


### PR DESCRIPTION
Add the config option to be able to toggle the use of `bcast` mode when clients enable tracking (CSC).