### PR TITLE
add option to filter out key prefixes from being cached

### DIFF
--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -28,7 +28,7 @@ message RedisProxy {
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
 
   // Redis connection pool settings.
-  // [#next-free-field: 15]
+  // [#next-free-field: 16]
   message ConnPoolSettings {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings";
@@ -160,6 +160,10 @@ message RedisProxy {
     // overhead the server needs to have per client. However, for Envoy this means that it will
     // recieve multiple invalidation messages for each worker thread.
     bool cache_enable_bcast_mode = 14;
+
+    // List of key prefixes to ignore for caching. Keys matching a prefix will not be looked
+    // for in the cache and requests will go directly to the upstream.
+    repeated string cache_ignore_key_prefixes = 15;
   }
 
   message PrefixRoutes {

--- a/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -29,7 +29,7 @@ message RedisProxy {
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
 
   // Redis connection pool settings.
-  // [#next-free-field: 15]
+  // [#next-free-field: 16]
   message ConnPoolSettings {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings";
@@ -161,6 +161,10 @@ message RedisProxy {
     // overhead the server needs to have per client. However, for Envoy this means that it will
     // recieve multiple invalidation messages for each worker thread.
     bool cache_enable_bcast_mode = 14;
+
+    // List of key prefixes to ignore for caching. Keys matching a prefix will not be looked
+    // for in the cache and requests will go directly to the upstream.
+    repeated string cache_ignore_key_prefixes = 15;
   }
 
   message PrefixRoutes {

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -252,6 +252,7 @@ private:
       return std::chrono::milliseconds(0);
     }
     bool cacheEnableBcastMode() const override { return false; };
+    std::vector<std::string> cacheIgnoreKeyPrefixes() const override { return std::vector<std::string>(); };
 
     // Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks
     void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -218,6 +218,12 @@ public:
    *         upstream Redis servers.
    */
   virtual bool cacheEnableBcastMode() const PURE;
+
+  /**
+   * @return list of key prefixes to ignore for caching. Requests for keys matching any of
+   * these prefixes will go to the upstream and won't be looked for in the cache.
+   */
+  virtual std::vector<std::string> cacheIgnoreKeyPrefixes() const PURE;
 };
 
 using ConfigSharedPtr = std::shared_ptr<Config>;

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -74,6 +74,7 @@ public:
   }
   std::chrono::milliseconds cacheTtl() const override { return cache_ttl_; }
   bool cacheEnableBcastMode() const override { return cache_enable_bcast_mode_; }
+  std::vector<std::string> cacheIgnoreKeyPrefixes() const override { return cache_ignore_key_prefixes_; }
 
 private:
   const std::chrono::milliseconds op_timeout_;
@@ -91,6 +92,7 @@ private:
   const std::chrono::milliseconds cache_buffer_flush_timeout_;
   const std::chrono::milliseconds cache_ttl_;
   const bool cache_enable_bcast_mode_;
+  const std::vector<std::string> cache_ignore_key_prefixes_;
 };
 
 class ClientImpl : public Client, public DecoderCallbacks, public CacheCallbacks, public Network::ConnectionCallbacks, public Logger::Loggable<Logger::Id::redis> {

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -107,6 +107,7 @@ private:
       return std::chrono::milliseconds(0);
     }
     bool cacheEnableBcastMode() const override { return false; };
+    std::vector<std::string> cacheIgnoreKeyPrefixes() const override { return std::vector<std::string>(); }
 
     // Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks
     void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;


### PR DESCRIPTION
Adds `cache_ignore_key_prefixes` which allows us to set which key prefixes will be ignored from caching.