### PR TITLE
expire cache keys on writes

### DIFF
--- a/source/extensions/filters/network/common/redis/cache_impl.h
+++ b/source/extensions/filters/network/common/redis/cache_impl.h
@@ -30,7 +30,8 @@ public:
   ~CacheImpl() override;
   bool makeCacheRequest(const RespValue& request) override;
   void set(const RespValue& request, const RespValue& response) override;
-  void expire(const RespValue& keys) override;
+  void invalidate(const RespValue& keys) override;
+  void expire(const RespValue& request) override;
   void addCallbacks(Client::CacheCallbacks& callbacks) override {
     this->callbacks_.push_front(&callbacks);
   }
@@ -51,7 +52,8 @@ public:
   void onBelowWriteBufferLowWatermark() override {}
 
 private:
-  const std::string* getRequestKey(const RespValue& request);
+  const std::string* readRequestKey(const RespValue& request);
+  const std::string* writeRequestKey(const RespValue& request);
 
   struct PendingCacheRequest : public Client::PoolRequest {
     PendingCacheRequest(const Operation op);

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -267,7 +267,8 @@ public:
 
   virtual bool makeCacheRequest(const RespValue& request) PURE;
   virtual void set(const RespValue& request, const RespValue& response) PURE;
-  virtual void expire(const RespValue& keys) PURE;
+  virtual void invalidate(const RespValue& keys) PURE;
+  virtual void expire(const RespValue& request) PURE;
   virtual void addCallbacks(CacheCallbacks& callbacks) PURE;
   virtual void clearCache(bool synchronous) PURE;
   virtual void initialize(const std::string& auth_username, const std::string& auth_password, bool clear_cache) PURE;

--- a/source/extensions/filters/network/common/redis/utility.cc
+++ b/source/extensions/filters/network/common/redis/utility.cc
@@ -42,7 +42,7 @@ HelloRequest::HelloRequest() {
 }
 
 ClientTrackingRequest::ClientTrackingRequest(bool enable_bcast_mode) {
-  int val_size = 3;
+  int val_size = 4;
   if (enable_bcast_mode) {
     val_size += 1;
   }
@@ -54,10 +54,12 @@ ClientTrackingRequest::ClientTrackingRequest(bool enable_bcast_mode) {
   values[1].asString() = "tracking";
   values[2].type(RespType::BulkString);
   values[2].asString() = "on";
+  values[3].type(RespType::BulkString);
+  values[3].asString() = "noloop";
 
   if (enable_bcast_mode) {
-    values[3].type(RespType::BulkString);
-    values[3].asString() = "bcast";
+    values[4].type(RespType::BulkString);
+    values[4].asString() = "bcast";
   }
 
   type(RespType::Array);


### PR DESCRIPTION
In order to avoid read after write inconsistencies write commands (`set`, `mset`, `del`) will cause the associated key to be deleted from the local cache before the command is sent upstream. This is used in conjunction with the `noloop` redis option so that redis does not send an invalidation message to the client performing the write since it already deleted the key.