### PR TITLE
shard the local cache based on upstream host address hash

### DIFF
--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -28,7 +28,7 @@ message RedisProxy {
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
 
   // Redis connection pool settings.
-  // [#next-free-field: 16]
+  // [#next-free-field: 17]
   message ConnPoolSettings {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings";
@@ -164,6 +164,10 @@ message RedisProxy {
     // List of key prefixes to ignore for caching. Keys matching a prefix will not be looked
     // for in the cache and requests will go directly to the upstream.
     repeated string cache_ignore_key_prefixes = 15;
+
+    // Number of shards to split cache into. This prevents the cache from being completely
+    // flushed when a single upstream host has issues and causes the cache to be flushed.
+    google.protobuf.UInt32Value cache_shards = 16 [(validate.rules).uint32 = {lt: 8192 gt: 0}];
   }
 
   message PrefixRoutes {

--- a/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -29,7 +29,7 @@ message RedisProxy {
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
 
   // Redis connection pool settings.
-  // [#next-free-field: 16]
+  // [#next-free-field: 17]
   message ConnPoolSettings {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings";
@@ -165,6 +165,10 @@ message RedisProxy {
     // List of key prefixes to ignore for caching. Keys matching a prefix will not be looked
     // for in the cache and requests will go directly to the upstream.
     repeated string cache_ignore_key_prefixes = 15;
+
+    // Number of shards to split cache into. This prevents the cache from being completely
+    // flushed when a single upstream host has issues and causes the cache to be flushed.
+    google.protobuf.UInt32Value cache_shards = 16 [(validate.rules).uint32 = {lt: 8192 gt: 0}];
   }
 
   message PrefixRoutes {

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -254,6 +254,10 @@ private:
     bool cacheEnableBcastMode() const override { return false; };
     std::vector<std::string> cacheIgnoreKeyPrefixes() const override { return std::vector<std::string>(); };
 
+    unsigned int cacheShards() const override {
+      return 1;
+    }
+
     // Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks
     void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;
     void onFailure() override;

--- a/source/extensions/filters/network/common/redis/cache_impl.h
+++ b/source/extensions/filters/network/common/redis/cache_impl.h
@@ -16,7 +16,8 @@ enum class Operation {
   Get,
   Set,
   Expire,
-  Flush
+  Flush,
+  Select
 };
 
 class CacheImpl : public Client::Cache, public Logger::Loggable<Logger::Id::redis>, public Client::ClientCallbacks, public Network::ConnectionCallbacks {
@@ -36,7 +37,7 @@ public:
     this->callbacks_.push_front(&callbacks);
   }
   void clearCache(bool synchronous) override;
-  void initialize(const std::string& auth_username, const std::string& auth_password, bool clear_cache) override;
+  void initialize(const std::string& auth_username, const std::string& auth_password, bool clear_cache, int db_slot) override;
 
   // Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks
   void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;
@@ -54,6 +55,7 @@ public:
 private:
   const std::string* readRequestKey(const RespValue& request);
   const std::string* writeRequestKey(const RespValue& request);
+  void selectDatabase(int db);
 
   struct PendingCacheRequest : public Client::PoolRequest {
     PendingCacheRequest(const Operation op);

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -224,6 +224,13 @@ public:
    * these prefixes will go to the upstream and won't be looked for in the cache.
    */
   virtual std::vector<std::string> cacheIgnoreKeyPrefixes() const PURE;
+
+  /**
+   * @return number of shards to split the cache into. This ensures that when one upstream
+   * redis node has an issue that the entire local cache is not flushed in the event that
+   * it is shared between all upstream nodes.
+   */
+  virtual uint32_t cacheShards() const PURE;
 };
 
 using ConfigSharedPtr = std::shared_ptr<Config>;
@@ -271,7 +278,7 @@ public:
   virtual void expire(const RespValue& request) PURE;
   virtual void addCallbacks(CacheCallbacks& callbacks) PURE;
   virtual void clearCache(bool synchronous) PURE;
-  virtual void initialize(const std::string& auth_username, const std::string& auth_password, bool clear_cache) PURE;
+  virtual void initialize(const std::string& auth_username, const std::string& auth_password, bool clear_cache, int db) PURE;
 };
 
 using CachePtr = std::unique_ptr<Cache>;

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -75,6 +75,7 @@ public:
   std::chrono::milliseconds cacheTtl() const override { return cache_ttl_; }
   bool cacheEnableBcastMode() const override { return cache_enable_bcast_mode_; }
   std::vector<std::string> cacheIgnoreKeyPrefixes() const override { return cache_ignore_key_prefixes_; }
+  uint32_t cacheShards() const override { return cache_shards_; }
 
 private:
   const std::chrono::milliseconds op_timeout_;
@@ -93,6 +94,7 @@ private:
   const std::chrono::milliseconds cache_ttl_;
   const bool cache_enable_bcast_mode_;
   const std::vector<std::string> cache_ignore_key_prefixes_;
+  const uint32_t cache_shards_;
 };
 
 class ClientImpl : public Client, public DecoderCallbacks, public CacheCallbacks, public Network::ConnectionCallbacks, public Logger::Loggable<Logger::Id::redis> {

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -109,6 +109,10 @@ private:
     bool cacheEnableBcastMode() const override { return false; };
     std::vector<std::string> cacheIgnoreKeyPrefixes() const override { return std::vector<std::string>(); }
 
+    unsigned int cacheShards() const override {
+      return 1;
+    }
+
     // Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks
     void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;
     void onFailure() override;


### PR DESCRIPTION
In order to avoid having the entire shared local cache flushed when a single upstream redis host has issues, I'm introducing the concept of cache sharding where the local cache will be split into buckets based on the upstream host. The caveat to this change is read replicas will for now be in different shards.