### PR TITLE
add read-write through caching

### DIFF
--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -28,7 +28,7 @@ message RedisProxy {
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
 
   // Redis connection pool settings.
-  // [#next-free-field: 17]
+  // [#next-free-field: 18]
   message ConnPoolSettings {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings";
@@ -55,6 +55,17 @@ message RedisProxy {
       // Read from any node of the cluster. A random node is selected among the primary and
       // replicas, healthy nodes have precedent over unhealthy nodes.
       ANY = 4;
+    }
+
+    // CachePolicy controls how Envoy uses the local cache.
+    enum CachePolicy {
+      // Write reponses for positive get requests from the upstream into the cache and
+      // check cache prior to reading from upstream.
+      READ_THROUGH = 0;
+
+      // Similar to READ_THROUGH but adds the writing of set requets to first the cache
+      // and then to the upstream.
+      READ_WRITE_THROUGH = 1;
     }
 
     // Per-operation timeout in milliseconds. The timer starts when the first
@@ -168,6 +179,8 @@ message RedisProxy {
     // Number of shards to split cache into. This prevents the cache from being completely
     // flushed when a single upstream host has issues and causes the cache to be flushed.
     google.protobuf.UInt32Value cache_shards = 16 [(validate.rules).uint32 = {lt: 8192 gt: 0}];
+
+    CachePolicy cache_policy = 17 [(validate.rules).enum = {defined_only: true}];
   }
 
   message PrefixRoutes {

--- a/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -29,7 +29,7 @@ message RedisProxy {
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
 
   // Redis connection pool settings.
-  // [#next-free-field: 17]
+  // [#next-free-field: 18]
   message ConnPoolSettings {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings";
@@ -56,6 +56,17 @@ message RedisProxy {
       // Read from any node of the cluster. A random node is selected among the primary and
       // replicas, healthy nodes have precedent over unhealthy nodes.
       ANY = 4;
+    }
+
+    // CachePolicy controls how Envoy uses the local cache.
+    enum CachePolicy {
+      // Write reponses for positive get requests from the upstream into the cache and
+      // check cache prior to reading from upstream.
+      READ_THROUGH = 0;
+
+      // Similar to READ_THROUGH but adds the writing of set requets to first the cache
+      // and then to the upstream.
+      READ_WRITE_THROUGH = 1;
     }
 
     // Per-operation timeout in milliseconds. The timer starts when the first
@@ -169,6 +180,8 @@ message RedisProxy {
     // Number of shards to split cache into. This prevents the cache from being completely
     // flushed when a single upstream host has issues and causes the cache to be flushed.
     google.protobuf.UInt32Value cache_shards = 16 [(validate.rules).uint32 = {lt: 8192 gt: 0}];
+
+    CachePolicy cache_policy = 17 [(validate.rules).enum = {defined_only: true}];
   }
 
   message PrefixRoutes {

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -258,6 +258,10 @@ private:
       return 1;
     }
 
+    Extensions::NetworkFilters::Common::Redis::Client::CachePolicy cachePolicy() const override {
+      return Extensions::NetworkFilters::Common::Redis::Client::CachePolicy::ReadThrough;
+    }
+
     // Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks
     void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;
     void onFailure() override;

--- a/source/extensions/filters/network/common/redis/cache_impl.h
+++ b/source/extensions/filters/network/common/redis/cache_impl.h
@@ -30,6 +30,7 @@ public:
   }
   ~CacheImpl() override;
   bool makeCacheRequest(const RespValue& request) override;
+  void set(const RespValue& request) override;
   void set(const RespValue& request, const RespValue& response) override;
   void invalidate(const RespValue& keys) override;
   void expire(const RespValue& request) override;
@@ -56,6 +57,7 @@ private:
   const std::string* readRequestKey(const RespValue& request);
   const std::string* writeRequestKey(const RespValue& request);
   void selectDatabase(int db);
+  const std::string* writeRequestValue(const RespValue& request);
 
   struct PendingCacheRequest : public Client::PoolRequest {
     PendingCacheRequest(const Operation op);

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -118,6 +118,11 @@ using ClientPtr = std::unique_ptr<Client>;
 enum class ReadPolicy { Primary, PreferPrimary, Replica, PreferReplica, Any };
 
 /**
+ * Cache policy to use for local cache.
+ */
+enum class CachePolicy { ReadThrough, ReadWriteThrough };
+
+/**
  * Configuration for a redis connection pool.
  */
 class Config {
@@ -231,6 +236,11 @@ public:
    * it is shared between all upstream nodes.
    */
   virtual uint32_t cacheShards() const PURE;
+
+  /**
+   * @return the cache policy the proxy should use.
+   */
+  virtual CachePolicy cachePolicy() const PURE;
 };
 
 using ConfigSharedPtr = std::shared_ptr<Config>;
@@ -273,6 +283,7 @@ public:
   ~Cache() override = default;
 
   virtual bool makeCacheRequest(const RespValue& request) PURE;
+  virtual void set(const RespValue& request) PURE;
   virtual void set(const RespValue& request, const RespValue& response) PURE;
   virtual void invalidate(const RespValue& keys) PURE;
   virtual void expire(const RespValue& request) PURE;

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -76,6 +76,7 @@ public:
   bool cacheEnableBcastMode() const override { return cache_enable_bcast_mode_; }
   std::vector<std::string> cacheIgnoreKeyPrefixes() const override { return cache_ignore_key_prefixes_; }
   uint32_t cacheShards() const override { return cache_shards_; }
+  CachePolicy cachePolicy() const override { return cache_policy_; }
 
 private:
   const std::chrono::milliseconds op_timeout_;
@@ -95,6 +96,7 @@ private:
   const bool cache_enable_bcast_mode_;
   const std::vector<std::string> cache_ignore_key_prefixes_;
   const uint32_t cache_shards_;
+  CachePolicy cache_policy_;
 };
 
 class ClientImpl : public Client, public DecoderCallbacks, public CacheCallbacks, public Network::ConnectionCallbacks, public Logger::Loggable<Logger::Id::redis> {

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -113,6 +113,10 @@ private:
       return 1;
     }
 
+    NetworkFilters::Common::Redis::Client::CachePolicy cachePolicy() const override {
+      return NetworkFilters::Common::Redis::Client::CachePolicy::ReadThrough;
+    }
+
     // Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks
     void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;
     void onFailure() override;


### PR DESCRIPTION
Up to now the cache has been read through but I'm now adding the ability to do read-through caching. This will be toggle-able via the `cache_policy` config variable.