### PR TITLE
add toggle for redis tracking

### DIFF
--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -28,7 +28,7 @@ message RedisProxy {
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
 
   // Redis connection pool settings.
-  // [#next-free-field: 17]
+  // [#next-free-field: 18]
   message ConnPoolSettings {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings";
@@ -168,6 +168,11 @@ message RedisProxy {
     // Number of shards to split cache into. This prevents the cache from being completely
     // flushed when a single upstream host has issues and causes the cache to be flushed.
     google.protobuf.UInt32Value cache_shards = 16 [(validate.rules).uint32 = {lt: 8192 gt: 0}];
+
+    // Disables use of key tracking by upstream Redis server. When this functionality is disabled
+    // Envoy will not receive invalidation messages for keys it has accessed. This may be desirable
+    // if invalidation messages are received via an alternate mechanism.
+    bool cache_disable_tracking = 17;
   }
 
   message PrefixRoutes {

--- a/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -29,7 +29,7 @@ message RedisProxy {
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
 
   // Redis connection pool settings.
-  // [#next-free-field: 17]
+  // [#next-free-field: 18]
   message ConnPoolSettings {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings";
@@ -169,6 +169,11 @@ message RedisProxy {
     // Number of shards to split cache into. This prevents the cache from being completely
     // flushed when a single upstream host has issues and causes the cache to be flushed.
     google.protobuf.UInt32Value cache_shards = 16 [(validate.rules).uint32 = {lt: 8192 gt: 0}];
+
+    // Disables use of key tracking by upstream Redis server. When this functionality is disabled
+    // Envoy will not receive invalidation messages for keys it has accessed. This may be desirable
+    // if invalidation messages are received via an alternate mechanism.
+    bool cache_disable_tracking = 17;
   }
 
   message PrefixRoutes {

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -258,6 +258,8 @@ private:
       return 1;
     }
 
+    bool cacheDisableTracking() const override { return false; }
+
     // Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks
     void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;
     void onFailure() override;

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -231,6 +231,15 @@ public:
    * it is shared between all upstream nodes.
    */
   virtual uint32_t cacheShards() const PURE;
+
+
+  /**
+   * @return whether to disable use of key tracking by upstream Redis server. When this
+   * functionality is disabled Envoy will not receive invalidation messages for keys it has
+   * accessed. This may be desirable if invalidation messages are received via an alternate
+   * mechanism.
+   */
+  virtual bool cacheDisableTracking() const PURE;
 };
 
 using ConfigSharedPtr = std::shared_ptr<Config>;

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -76,6 +76,7 @@ public:
   bool cacheEnableBcastMode() const override { return cache_enable_bcast_mode_; }
   std::vector<std::string> cacheIgnoreKeyPrefixes() const override { return cache_ignore_key_prefixes_; }
   uint32_t cacheShards() const override { return cache_shards_; }
+  bool cacheDisableTracking() const override { return cache_disable_tracking_; }
 
 private:
   const std::chrono::milliseconds op_timeout_;
@@ -95,6 +96,7 @@ private:
   const bool cache_enable_bcast_mode_;
   const std::vector<std::string> cache_ignore_key_prefixes_;
   const uint32_t cache_shards_;
+  const bool cache_disable_tracking_;
 };
 
 class ClientImpl : public Client, public DecoderCallbacks, public CacheCallbacks, public Network::ConnectionCallbacks, public Logger::Loggable<Logger::Id::redis> {

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -112,6 +112,8 @@ private:
     unsigned int cacheShards() const override {
       return 1;
     }
+    bool cacheDisableTracking() const override { return false; }
+
 
     // Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks
     void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;


### PR DESCRIPTION
Adds a toggle to disable the use of server tracking. This toggle allows the use of the cache without also subscribing the clients to invalidation messages. This may be desirable if there is an alternate method of invalidation.