### PR TITLE
disable flush on start when tracking disabled

### DIFF
--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -505,7 +505,7 @@ ClientPtr ClientFactoryImpl::create(Upstream::HostConstSharedPtr host,
     ClientPtr cache_client = ClientImpl::create(cache_host, dispatcher, EncoderPtr{new EncoderImpl(RespVersion::Resp3)},
                                       decoder_factory_, *cache_config, redis_command_stats, cache_host->cluster().statsScope(), nullptr);
     cp = cache_factory_.create(std::move(cache_client), config.cacheTtl(), config.cacheIgnoreKeyPrefixes());
-    cp->initialize(auth_username, auth_password, true, shard);
+    cp->initialize(auth_username, auth_password, !config.cacheDisableTracking(), shard);
   }
 
   ClientPtr client = ClientImpl::create(host, dispatcher, EncoderPtr{new EncoderImpl(RespVersion::Resp3)},


### PR DESCRIPTION
Disable flushing of cache when tracking is also disabled. This assumes the flushing will be done via whatever is doing the tracking.