### PR TITLE
only use resp3 when using CSC due to compatibility issues

### DIFF
--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -102,14 +102,17 @@ private:
 
 class ClientImpl : public Client, public DecoderCallbacks, public CacheCallbacks, public Network::ConnectionCallbacks, public Logger::Loggable<Logger::Id::redis> {
 public:
-  static ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
-                          EncoderPtr&& encoder, DecoderFactory& decoder_factory,
+  static ClientPtr create(const RespVersion resp_version,
+                          Upstream::HostConstSharedPtr host,
+                          Event::Dispatcher& dispatcher,
+                          EncoderPtr&& encoder,
+                          DecoderFactory& decoder_factory,
                           const Config& config,
                           const RedisCommandStatsSharedPtr& redis_command_stats,
                           Stats::Scope& scope,
                           CachePtr&& cache);
 
-  ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher, EncoderPtr&& encoder,
+  ClientImpl(const RespVersion resp_version, Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher, EncoderPtr&& encoder,
              DecoderFactory& decoder_factory, const Config& config,
              const RedisCommandStatsSharedPtr& redis_command_stats, Stats::Scope& scope, CachePtr&& cache);
   ~ClientImpl() override;
@@ -173,6 +176,7 @@ private:
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 
+  RespVersion resp_version_;
   Upstream::HostConstSharedPtr host_;
   Network::ClientConnectionPtr connection_;
   EncoderPtr encoder_;

--- a/source/extensions/filters/network/common/redis/utility.cc
+++ b/source/extensions/filters/network/common/redis/utility.cc
@@ -1,5 +1,6 @@
 #include "source/extensions/filters/network/common/redis/utility.h"
 
+#include "codec.h"
 #include "source/common/common/utility.h"
 
 namespace Envoy {
@@ -31,12 +32,24 @@ AuthRequest::AuthRequest(const std::string& username, const std::string& passwor
   asArray().swap(values);
 }
 
-HelloRequest::HelloRequest() {
+HelloRequest::HelloRequest(const RespVersion resp_version) {
   std::vector<RespValue> values(2);
   values[0].type(RespType::BulkString);
   values[0].asString() = "hello";
   values[1].type(RespType::BulkString);
-  values[1].asString() = "3";
+
+  switch (resp_version) {
+    case RespVersion::Resp2:
+      values[1].asString() = "2";
+      break;
+    case RespVersion::Resp3:
+      values[1].asString() = "3";
+      break;
+    default:
+      NOT_REACHED_GCOVR_EXCL_LINE;
+      break;
+  }
+
   type(RespType::Array);
   asArray().swap(values);
 }

--- a/source/extensions/filters/network/common/redis/utility.h
+++ b/source/extensions/filters/network/common/redis/utility.h
@@ -19,7 +19,7 @@ public:
 
 class HelloRequest : public Redis::RespValue {
 public:
-  HelloRequest();
+  HelloRequest(const RespVersion resp_version);
 };
 
 class ClientTrackingRequest : public Redis::RespValue {


### PR DESCRIPTION
We found out that wire format for `ZRANGE` differs between `RESP3` and `RESP2` and it's not entirely obvious how to safely translate between the two protocol versions. Instead of always using `RESP3` only use it when CSC is enabled. The caveat is some commands may not work.